### PR TITLE
update WHS signup link

### DIFF
--- a/src/components/SessionWidget.astro
+++ b/src/components/SessionWidget.astro
@@ -128,7 +128,7 @@ import 'leaflet/dist/leaflet.css';
 						address: '249 Taranaki Street, Mt Cook, 6011, Wellington',
 						latlong: [-41.300334, 174.775107],
 						age: 'Years 9-13 (Ages 13-18)',
-						signupLink: 'https://forms.gle/hJiRmvQF6QcjmJjt9',
+						signupLink: 'https://forms.gle/BQdeQFkCYxUV45Tr7',
 						time: 'Tuesday at 3:30 - 5:30pm',
 					},
 					// {


### PR DESCRIPTION
Changed Google Forms link on https://tuhuratech.org.nz/mahi/sessions/ to a new one (placed in the 2025 Gdrive in a new WHS folder)

Fails a Prettier check -- but so does the upstream which builds correctly nevertheless. 